### PR TITLE
Made functionality button play search panel

### DIFF
--- a/src/assets/icons/pause.svg
+++ b/src/assets/icons/pause.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" aria-label="Pause" role="img">
 
-    <path d="M8 7h3v10H8zM13 7h3v10h-3z" fill="currentColor" />
+    <path d="M8 7h3v10H8zM13 7h3v10h-3z" fill="white" />
 </svg>

--- a/src/assets/icons/pause.svg
+++ b/src/assets/icons/pause.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" aria-label="Pause" role="img">
+
+    <path d="M8 7h3v10H8zM13 7h3v10h-3z" fill="currentColor" />
+</svg>

--- a/src/assets/icons/play.svg
+++ b/src/assets/icons/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" aria-label="Play" role="img">
+    <path d="M9 7v10l8-5-8-5z" fill="currentColor" />
+</svg>

--- a/src/assets/icons/play.svg
+++ b/src/assets/icons/play.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" aria-label="Play" role="img">
-    <path d="M9 7v10l8-5-8-5z" fill="currentColor" />
+    <path d="M9 7v10l8-5-8-5z" fill="white" />
 </svg>

--- a/src/components/AlbumCarrousel.astro
+++ b/src/components/AlbumCarrousel.astro
@@ -8,7 +8,7 @@ const { album, title } = Astro.props;
     {
       album.items.map((item) => (
         <div class="container-for-play" style="position: relative;">
-          <button class="btn-album-go-to" data-album-id={item.id}>
+          <button class="btn-album-go-to " data-album-id={item.id}>
             <div>
               <img
                 class="img-album"
@@ -21,7 +21,12 @@ const { album, title } = Astro.props;
               <span>{item?.artists?.map((a) => a.name).join(", ")}</span>
             </div>
           </button>
-          <button class="btn-hidden">▶</button>
+          <button
+            class="btn-hidden playSong-Album-Carrousel"
+            data-track-album={item.uri}
+          >
+            ▶
+          </button>
         </div>
       ))
     }

--- a/src/components/AlbumCarrousel.astro
+++ b/src/components/AlbumCarrousel.astro
@@ -1,5 +1,6 @@
 ---
 const { album, title } = Astro.props;
+import PlayIcon from "../assets/icons/play.svg?url";
 ---
 
 <div>
@@ -12,7 +13,7 @@ const { album, title } = Astro.props;
             <div>
               <img
                 class="img-album"
-                src={item?.images[1].url}
+                src={item?.images[1]?.url}
                 alt=""
                 srcset=""
                 width="153"
@@ -24,8 +25,19 @@ const { album, title } = Astro.props;
           <button
             class="btn-hidden playSong-Album-Carrousel"
             data-track-album={item.uri}
+            data-track={JSON.stringify({
+              id: item.id,
+              uri: item.uri,
+              name: item.name,
+            })}
           >
-            ▶
+            <img
+              src={PlayIcon}
+              alt="play icon"
+              srcset=""
+              data-state="play"
+              class={`btn-hidden-pause-${item.id}`}
+            />
           </button>
         </div>
       ))

--- a/src/components/ArtistCarrousel.astro
+++ b/src/components/ArtistCarrousel.astro
@@ -1,5 +1,9 @@
 ---
 export const prerender = false;
+
+import PlayIcon from "../assets/icons/play.svg?url";
+import PauseIcon from "../assets/icons/pause.svg?url";
+
 const { artists, title } = Astro.props;
 ---
 
@@ -30,7 +34,7 @@ const { artists, title } = Astro.props;
             <div class="wrapper-for-img-your-favorite-artists">
               <img
                 class="img-favorite-artists"
-                src={item?.images[2].url}
+                src={item?.images[1].url}
                 alt=""
                 srcset=""
                 width="153"
@@ -39,7 +43,12 @@ const { artists, title } = Astro.props;
               <div>{item?.name}</div>
             </div>
           </button>
-          <button class="btn-hidden">▶</button>
+          <button
+            class="btn-hidden playSong-Artists-Carrousel"
+            data-track-artist={item.uri}
+          >
+            <img src={PlayIcon} alt="play icon" srcset="" />
+          </button>
         </div>
       ))
     }

--- a/src/components/ArtistCarrousel.astro
+++ b/src/components/ArtistCarrousel.astro
@@ -2,7 +2,6 @@
 export const prerender = false;
 
 import PlayIcon from "../assets/icons/play.svg?url";
-import PauseIcon from "../assets/icons/pause.svg?url";
 
 const { artists, title } = Astro.props;
 ---
@@ -34,7 +33,7 @@ const { artists, title } = Astro.props;
             <div class="wrapper-for-img-your-favorite-artists">
               <img
                 class="img-favorite-artists"
-                src={item?.images[1].url}
+                src={item?.images[1]?.url}
                 alt=""
                 srcset=""
                 width="153"
@@ -46,8 +45,19 @@ const { artists, title } = Astro.props;
           <button
             class="btn-hidden playSong-Artists-Carrousel"
             data-track-artist={item.uri}
+            data-track={JSON.stringify({
+              id: item.id,
+              uri: item.uri,
+              name: item.name,
+            })}
           >
-            <img src={PlayIcon} alt="play icon" srcset="" />
+            <img
+              src={PlayIcon}
+              alt="play icon"
+              srcset=""
+              data-state="play"
+              class={`btn-hidden-pause-${item.id}`}
+            />
           </button>
         </div>
       ))

--- a/src/components/CentralPanel.astro
+++ b/src/components/CentralPanel.astro
@@ -13,6 +13,8 @@ import Footer from "./Footer.astro";
   import { getColor } from "@/scripts/getColor";
   import { loadSpotifyPlayer } from "@/scripts/player";
   import { spotifyPlayerAction } from "@/scripts/spotifyPlayerAction";
+  import { localStorageGet, localStorageSet } from "src/utils/localStorage";
+  import { handleColorGreen } from "src/utils/handleColorGreen";
   const root = document.getElementById("center-panel");
 
   async function renderHome() {
@@ -50,21 +52,23 @@ import Footer from "./Footer.astro";
   function addEventTopResults() {
     const btnElementTopResult = document.querySelector(".top-result");
     const btnTopResultUriSong = btnElementTopResult.dataset.topResultSong;
-    document.querySelector(".playSong").onclick = async function () {
+    const mainTop = document.querySelector(".playSong");
+    mainTop.onclick = async function () {
+      debugger;
+      handleColorGreen({
+        allowed: "playSong-main-top-song",
+        trackData: JSON.parse(mainTop.dataset.track),
+      });
       await spotifyPlayerAction("play", {
         uris: [btnTopResultUriSong],
         deviceId: window.deviceId,
       });
+      const parsedMainTop = JSON.parse(mainTop.dataset.track);
+      parsedMainTop.class = "playSong-top-songs";
+      localStorageSet("lastPlayedTrack", parsedMainTop);
     };
 
     ///
-    const parseJSON = (s, fb = null) => {
-      try {
-        return JSON.parse(s);
-      } catch {
-        return fb;
-      }
-    };
 
     const isSameTrack = (a, b) => {
       if (!a || !b) return false;
@@ -78,11 +82,11 @@ import Footer from "./Footer.astro";
     const buttons = Array.from(
       document.querySelectorAll(".playSong-top-songs")
     );
-    const lastPlayed = parseJSON(localStorage.getItem("lastPlayedTrack"));
+    const lastPlayed = localStorageGet("lastPlayedTrack");
 
     const matchedBtn = lastPlayed
       ? buttons.find((btn) => {
-          const data = parseJSON(btn.dataset.track);
+          const data = JSON.parse(btn.dataset.track);
           return isSameTrack(data, lastPlayed);
         })
       : null;
@@ -95,11 +99,14 @@ import Footer from "./Footer.astro";
     }
 
     buttons.forEach((btn) => {
-      const trackData = parseJSON(btn.dataset.track);
+      const trackData = JSON.parse(btn.dataset.track);
 
       btn.onclick = async () => {
         trackData.class = "playSong-top-songs";
-        localStorage.setItem("lastPlayedTrack", JSON.stringify(trackData));
+        debugger;
+        handleColorGreen({ allowed: "playSong-top-songs", trackData });
+
+        localStorageSet("lastPlayedTrack", trackData);
 
         const uri = btn.dataset.trackUri;
         try {
@@ -116,6 +123,12 @@ import Footer from "./Footer.astro";
     ///
     document.querySelectorAll(".playSong-Artists-Carrousel").forEach((btn) => {
       btn.onclick = async () => {
+        const trackData = JSON.parse(btn.dataset.track);
+        trackData.class = "playSong-top-songs";
+        handleColorGreen({ allowed: "playSong-Artists-Carrousel", trackData });
+
+        localStorageSet("lastPlayedTrack", trackData);
+
         const uri = btn.dataset.trackArtist;
         console.log(uri);
         await spotifyPlayerAction("play", {
@@ -125,6 +138,12 @@ import Footer from "./Footer.astro";
     });
     document.querySelectorAll(".playSong-Album-Carrousel").forEach((btn) => {
       btn.onclick = async () => {
+        const trackData = JSON.parse(btn.dataset.track);
+        trackData.class = "playSong-top-songs";
+        handleColorGreen({ allowed: "playSong-Album-Carrousel", trackData });
+
+        localStorageSet("lastPlayedTrack", trackData);
+
         const uri = btn.dataset.trackAlbum;
         console.log(uri);
         await spotifyPlayerAction("play", {
@@ -230,7 +249,6 @@ import Footer from "./Footer.astro";
       addEventNavArtist(".artist-with-search");
       addEventNavAlbum(".btn-album-go-to");
       addEventTopResults();
-      // getColor();
     } catch (e) {
       root.innerHTML = `<p>Error.</p>`;
       console.error(e);

--- a/src/components/CentralPanel.astro
+++ b/src/components/CentralPanel.astro
@@ -12,7 +12,7 @@ import Footer from "./Footer.astro";
 <script>
   import { getColor } from "@/scripts/getColor";
   import { loadSpotifyPlayer } from "@/scripts/player";
-  import { getSpotifyToken } from "../utils/get-spotify-token";
+  import { spotifyPlayerAction } from "@/scripts/spotifyPlayerAction";
   const root = document.getElementById("center-panel");
 
   async function renderHome() {
@@ -46,6 +46,96 @@ import Footer from "./Footer.astro";
         );
       });
     });
+  }
+  function addEventTopResults() {
+    const btnElementTopResult = document.querySelector(".top-result");
+    const btnTopResultUriSong = btnElementTopResult.dataset.topResultSong;
+    document.querySelector(".playSong").onclick = async function () {
+      await spotifyPlayerAction("play", {
+        uris: [btnTopResultUriSong],
+        deviceId: window.deviceId,
+      });
+    };
+
+    ///
+    const parseJSON = (s, fb = null) => {
+      try {
+        return JSON.parse(s);
+      } catch {
+        return fb;
+      }
+    };
+
+    const isSameTrack = (a, b) => {
+      if (!a || !b) return false;
+      if (a.id !== b.id) return false;
+      if (a.name !== b.name) return false;
+      if (a.album?.id !== b.album?.id) return false;
+      if ((a.artists?.length || 0) !== (b.artists?.length || 0)) return false;
+      return a.artists.every((art, i) => art.id === b.artists[i].id);
+    };
+
+    const buttons = Array.from(
+      document.querySelectorAll(".playSong-top-songs")
+    );
+    const lastPlayed = parseJSON(localStorage.getItem("lastPlayedTrack"));
+
+    const matchedBtn = lastPlayed
+      ? buttons.find((btn) => {
+          const data = parseJSON(btn.dataset.track);
+          return isSameTrack(data, lastPlayed);
+        })
+      : null;
+
+    if (matchedBtn) {
+      console.log(
+        "Hay coincidencia con el último guardado:",
+        matchedBtn.dataset.track
+      );
+    }
+
+    buttons.forEach((btn) => {
+      const trackData = parseJSON(btn.dataset.track);
+
+      btn.onclick = async () => {
+        trackData.class = "playSong-top-songs";
+        localStorage.setItem("lastPlayedTrack", JSON.stringify(trackData));
+
+        const uri = btn.dataset.trackUri;
+        try {
+          await spotifyPlayerAction("play", {
+            uris: [uri],
+            deviceId: window.deviceId,
+          });
+        } catch (e) {
+          console.error("Error al reproducir:", e);
+        }
+      };
+    });
+
+    ///
+    document.querySelectorAll(".playSong-Artists-Carrousel").forEach((btn) => {
+      btn.onclick = async () => {
+        const uri = btn.dataset.trackArtist;
+        console.log(uri);
+        await spotifyPlayerAction("play", {
+          context_uri: uri,
+        });
+      };
+    });
+    document.querySelectorAll(".playSong-Album-Carrousel").forEach((btn) => {
+      btn.onclick = async () => {
+        const uri = btn.dataset.trackAlbum;
+        console.log(uri);
+        await spotifyPlayerAction("play", {
+          context_uri: uri,
+        });
+      };
+    });
+
+    // document.querySelector("pauseSong").onclick = async function () {
+    //   await spotifyPlayerAction("pause");
+    // };
   }
   async function renderAlbumById(albumId) {
     root.innerHTML = `<p>Cargando álbum ${albumId}...</p>`;
@@ -92,35 +182,14 @@ import Footer from "./Footer.astro";
         const track_uri = JSON.parse(
           document.querySelector(".btn-play")?.dataset.tracksAlbum
         );
-
-        const res = await fetch(
-          `https://api.spotify.com/v1/me/player/play?device_id=${window.deviceId}`,
-          {
-            method: "PUT",
-            body: JSON.stringify({ uris: track_uri }),
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${await getSpotifyToken()}`,
-            },
-          }
-        );
-        if (res.status === 204) {
-          // alert("Playback started!");
-        } else {
-          // TODO: IF FAIL, FETCH TOKEN TO FIND DEVICEID
-          const data = await res.json();
-          alert("Failed: " + JSON.stringify(data));
-        }
+        await spotifyPlayerAction("play", {
+          uris: track_uri,
+          deviceId: window.deviceId,
+        });
       };
 
       document.getElementById("pauseSong").onclick = async function () {
-        await fetch("https://api.spotify.com/v1/me/player/pause", {
-          method: "PUT",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        console.log("Playback paused via Web API!");
+        await spotifyPlayerAction("pause");
       };
       /////////
     } catch (e) {
@@ -160,6 +229,7 @@ import Footer from "./Footer.astro";
       root.innerHTML = html;
       addEventNavArtist(".artist-with-search");
       addEventNavAlbum(".btn-album-go-to");
+      addEventTopResults();
       // getColor();
     } catch (e) {
       root.innerHTML = `<p>Error.</p>`;

--- a/src/components/Search/TopTracks.astro
+++ b/src/components/Search/TopTracks.astro
@@ -35,7 +35,10 @@ function formatDuration(ms: number) {
         }</span
       >
     </div>
-    <button class="btn-hidden">▶</button>
+    <button
+      class="btn-hidden top-result playSong"
+      data-top-result-song={tracks.items[0].uri}>▶</button
+    >
   </div>
   <div style="flex:1;padding-right: 10px;">
     <h2>Songs</h2>
@@ -54,7 +57,26 @@ function formatDuration(ms: number) {
                 height="40"
               />
               <div class="overlay">
-                <span>▶</span>
+                <button
+                  class="btn-top-tracks playSong-top-songs"
+                  data-track-uri={track.uri}
+                  data-track={JSON.stringify({
+                    id: track.id,
+                    uri: track.uri,
+                    name: track.name,
+                    album: {
+                      id: track.album.id,
+                      name: track.album.name,
+                      images: track.album.images,
+                    },
+                    artists: track.artists.map((a) => ({
+                      id: a.id,
+                      name: a.name,
+                    })),
+                  })}
+                >
+                  <span>▶</span>
+                </button>
               </div>
             </div>
             <div style="justify-content: space-between;display: flex;flex: 1;">

--- a/src/components/Search/TopTracks.astro
+++ b/src/components/Search/TopTracks.astro
@@ -1,5 +1,7 @@
 ---
 const { tracks } = Astro.props;
+import PlayIcon from "src/assets/icons/play.svg?url";
+
 function formatDuration(ms: number) {
   const m = Math.floor(ms / 60000);
   const s = Math.floor((ms % 60000) / 1000)
@@ -37,7 +39,29 @@ function formatDuration(ms: number) {
     </div>
     <button
       class="btn-hidden top-result playSong"
-      data-top-result-song={tracks.items[0].uri}>▶</button
+      data-top-result-song={tracks.items[0].uri}
+      data-track={JSON.stringify({
+        id: tracks?.items[0].id,
+        uri: tracks?.items[0].uri,
+        name: tracks?.items[0].name,
+        album: {
+          id: tracks?.items[0].album.id,
+          name: tracks?.items[0].album.name,
+          images: tracks?.items[0].album.images,
+        },
+        artists: tracks?.items[0].artists.map((a) => ({
+          id: a.id,
+          name: a.name,
+        })),
+      })}
+    >
+      <img
+        src={PlayIcon}
+        alt=""
+        srcset=""
+        data-state="play"
+        class={`btn-hidden-pause-${tracks?.items[0]?.id}`}
+      /></button
     >
   </div>
   <div style="flex:1;padding-right: 10px;">
@@ -75,13 +99,19 @@ function formatDuration(ms: number) {
                     })),
                   })}
                 >
-                  <span>▶</span>
+                  <img
+                    data-state="play"
+                    class={`btn-hidden-pause-${track.id}`}
+                    src={PlayIcon}
+                    alt=""
+                    srcset=""
+                  />
                 </button>
               </div>
             </div>
             <div style="justify-content: space-between;display: flex;flex: 1;">
               <div style="display: flex; flex-direction: column;">
-                <span>{track?.name}</span>
+                <span class={`track-song-${track.id}`}>{track?.name}</span>
                 <span>{track?.artists?.map((a) => a?.name).join(", ")}</span>
               </div>
               <span>{formatDuration(track?.duration_ms)}</span>

--- a/src/scripts/checkTracks.ts
+++ b/src/scripts/checkTracks.ts
@@ -1,0 +1,24 @@
+export function checkTrack(tracks: [], ElementName: string) {
+  const data = JSON.parse(btn.dataset.track);
+
+  // buscar el track original en tu índice
+  const original = TRACKS_BY_ID.get(data.id);
+
+  if (!original) {
+    console.warn("No se encontró el track original con id", data.id);
+    return;
+  }
+
+  // verificar coincidencias simples
+  const sameName = original.name === data.name;
+  const sameAlbum = original.album.id === data.album.id;
+  const sameArtists = data.artists.every(
+    (a, idx) => a.id === original.artists[idx].id
+  );
+
+  if (sameName && sameAlbum && sameArtists) {
+    console.log("El track reducido coincide con el original", data.id);
+  } else {
+    console.log("Diferencias detectadas entre data-track y el track original");
+  }
+}

--- a/src/scripts/refreshPanel.ts
+++ b/src/scripts/refreshPanel.ts
@@ -1,0 +1,44 @@
+import { getSpotifyToken } from "src/utils/get-spotify-token";
+
+let lastProgress = 0;
+let lastTrackId: number | null = null;
+
+async function fetchState(token: string | null = null) {
+  if (token === null) {
+    token = await getSpotifyToken();
+  }
+  const res = await fetch("https://api.spotify.com/v1/me/player", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (res.status === 204) return null;
+  if (!res.ok) throw new Error("No se pudo obtener estado");
+
+  return res.json();
+}
+
+export async function refreshPanel(token: string | null = null) {
+  const state = await fetchState(token);
+  if (!state?.item) return;
+
+  const currentTrackId = state.item.id;
+  const currentProgress = state.progress_ms;
+
+  const trackChanged = currentTrackId !== lastTrackId;
+  const jumped = Math.abs(currentProgress - lastProgress) > 5000; // 5s tolerancia
+
+  if (trackChanged || jumped) {
+    // renderNowPlaying(state.item); here i going to dispatch the events
+    clearTimeout(window.nextRefresh);
+
+    const remaining = state.item.duration_ms - state.progress_ms;
+    window.nextRefresh = setTimeout(refreshPanel, remaining + 1000);
+
+    lastTrackId = currentTrackId;
+  }
+
+  lastProgress = currentProgress;
+}
+
+setInterval(refreshPanel, 10000);
+refreshPanel();

--- a/src/scripts/seekTo.ts
+++ b/src/scripts/seekTo.ts
@@ -1,0 +1,23 @@
+import { getSpotifyToken } from "src/utils/get-spotify-token";
+import { refreshPanel } from "./refreshPanel";
+
+export async function seekTo(positionMs: number, deviceId = null) {
+  const token = await getSpotifyToken();
+  const url = new URL("https://api.spotify.com/v1/me/player/seek");
+  url.searchParams.set("position_ms", positionMs.toString());
+  if (deviceId) url.searchParams.set("device_id", deviceId);
+
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error("Seek failed: " + res.status);
+  }
+
+  // Recalcular estado y reprogramar refresh
+  await refreshPanel();
+}

--- a/src/scripts/spotifyPlayerAction.ts
+++ b/src/scripts/spotifyPlayerAction.ts
@@ -1,0 +1,107 @@
+import { getSpotifyToken } from "../utils/get-spotify-token";
+
+type PlayOptions = {
+  deviceId?: string | null;
+  context_uri?: string;
+  uris?: string[] | null;
+  offset?: number | { uri: string };
+  position_ms?: number;
+};
+
+export async function spotifyPlayerAction(
+  action: "play" | "pause" | "next" | "previous",
+  {
+    deviceId = null,
+    context_uri = undefined,
+    uris = null,
+    offset,
+    position_ms,
+  }: PlayOptions = {}
+) {
+  const token = await getSpotifyToken();
+  let url = "";
+  let method: "PUT" | "POST" = "PUT";
+  let body: any = null;
+
+  if (!deviceId && action === "play") {
+    deviceId = await getActiveOrFirstDeviceId(token);
+  }
+
+  switch (action) {
+    case "play": {
+      url = `https://api.spotify.com/v1/me/player/play${
+        deviceId ? `?device_id=${encodeURIComponent(deviceId)}` : ""
+      }`;
+
+      const payload: Record<string, any> = {};
+      if (context_uri) payload.context_uri = context_uri;
+      if (uris?.length) payload.uris = uris;
+
+      if (typeof offset !== "undefined") {
+        payload.offset =
+          typeof offset === "number" ? { position: offset } : offset;
+      }
+
+      if (typeof position_ms === "number") {
+        payload.position_ms = position_ms;
+      }
+
+      body = Object.keys(payload).length ? JSON.stringify(payload) : null;
+      break;
+    }
+
+    case "pause":
+      url = "https://api.spotify.com/v1/me/player/pause";
+      break;
+
+    case "next":
+      url = "https://api.spotify.com/v1/me/player/next";
+      method = "POST";
+      break;
+
+    case "previous":
+      url = "https://api.spotify.com/v1/me/player/previous";
+      method = "POST";
+      break;
+
+    default:
+      throw new Error(`Acción desconocida: ${action as string}`);
+  }
+
+  const res = await fetch(url, {
+    method,
+    body,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (res.status === 204) {
+    console.log(`✅ Acción ${action} ejecutada correctamente`);
+    return { ok: true };
+  }
+
+  let data: any = null;
+  try {
+    data = await res.json();
+  } catch (_) {
+    /* ignore */
+  }
+  console.error(`❌ Acción ${action} falló:`, data || res.statusText);
+  return { ok: false, status: res.status, error: data || res.statusText };
+}
+
+async function getActiveOrFirstDeviceId(
+  token: string
+): Promise<string | undefined> {
+  const res = await fetch("https://api.spotify.com/v1/me/player/devices", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) return undefined;
+  const json = await res.json();
+  const devices: Array<{ id: string; is_active: boolean }> =
+    json?.devices || [];
+  return devices.find((d) => d.is_active)?.id || devices[0]?.id || undefined;
+}

--- a/src/styles/CenterPanel.css
+++ b/src/styles/CenterPanel.css
@@ -143,3 +143,7 @@ display: flex;
 justify-content: center;
 align-items: center;
 }
+
+.text-playing{
+    color: #0077ff;
+}

--- a/src/utils/handleColorGreen.ts
+++ b/src/utils/handleColorGreen.ts
@@ -1,0 +1,140 @@
+import { localStorageGet } from "./localStorage";
+import PauseIcon from "src/assets/icons/pause.svg?url";
+import PlayIcon from "src/assets/icons/play.svg?url";
+const CLASSNAME = "text-playing";
+type actions = {
+  allowed:
+    | "playSong-main-top-song"
+    | "playSong-top-songs"
+    | "playSong-Artists-Carrousel"
+    | "playSong-Album-Carrousel";
+  trackData: object;
+};
+function setColorGreen(element: HTMLElement | Element) {
+  element.classList.add(CLASSNAME);
+}
+function removeColorGreen(element: HTMLElement | Element) {
+  element.classList.remove(CLASSNAME);
+}
+function toggleBtnIcon(imgButton: HTMLImageElement | Element) {
+  debugger;
+  console.log(imgButton.dataset.state);
+  if (imgButton.dataset.state === "play") {
+    imgButton.src = PauseIcon;
+    imgButton.dataset.state = "stopped";
+  } else {
+    imgButton.src = PlayIcon;
+    imgButton.dataset.state = "play";
+  }
+}
+
+function removeLastPlayed(lastPlayed: string) {
+  if (lastPlayed && lastPlayed.class === "playSong-top-songs") {
+    //search for the last song
+    const textSong = document.querySelector(`.track-song-${lastPlayed.id}`);
+    if (textSong !== null) {
+      removeColorGreen(textSong);
+    }
+    // toggle icon
+    const imgButton = document.querySelectorAll(
+      `.btn-hidden-pause-${lastPlayed.id}`
+    );
+    if (imgButton !== null) {
+      imgButton.forEach((img) => {
+        img.dataset.state = "pause";
+        toggleBtnIcon(img);
+      });
+    }
+  } else if (lastPlayed && lastPlayed.class === "playSong-Artists-Carrousel") {
+    const textSong = document.querySelector(`.track-song-${lastPlayed.id}`);
+    if (textSong !== null) {
+      removeColorGreen(textSong);
+    }
+  }
+}
+function addCurrentSong(trackData: Object) {
+  const textSong = document.querySelector(`.track-song-${trackData.id}`);
+  if (textSong !== null) {
+    setColorGreen(textSong);
+  }
+  const imgButton = document.querySelectorAll(
+    `.btn-hidden-pause-${trackData.id}`
+  );
+  if (imgButton !== null) {
+    imgButton.forEach((img) => {
+      toggleBtnIcon(img);
+    });
+  }
+}
+
+function handleTopSongs(trackData: Object) {
+  const lastPlayed = localStorageGet("lastPlayedTrack");
+  if (lastPlayed.id !== trackData.id) {
+    removeLastPlayed(lastPlayed);
+  }
+
+  addCurrentSong(trackData);
+}
+
+function handleMainTopSong(trackData: Object) {
+  //remove top song
+  const lastPlayed = localStorageGet("lastPlayedTrack");
+  if (lastPlayed.id !== trackData.id) {
+    removeLastPlayed(lastPlayed);
+  }
+  const imgButton = document.querySelectorAll(
+    `.btn-hidden-pause-${trackData.id}`
+  );
+  if (imgButton !== null) {
+    imgButton.forEach((img) => {
+      toggleBtnIcon(img);
+    });
+  }
+}
+
+function handleArtistCarrousel(trackData: object) {
+  const lastPlayed = localStorageGet("lastPlayedTrack");
+  if (lastPlayed.id !== trackData.id) {
+    removeLastPlayed(lastPlayed);
+  }
+  const imgButton = document.querySelectorAll(
+    `.btn-hidden-pause-${trackData.id}`
+  );
+  if (imgButton !== null) {
+    imgButton.forEach((img) => {
+      toggleBtnIcon(img);
+    });
+  }
+}
+
+function handleAlbumCarrousel(trackData: object) {
+  const lastPlayed = localStorageGet("lastPlayedTrack");
+  if (lastPlayed.id !== trackData.id) {
+    removeLastPlayed(lastPlayed);
+  }
+  const imgButton = document.querySelectorAll(
+    `.btn-hidden-pause-${trackData.id}`
+  );
+  if (imgButton !== null) {
+    imgButton.forEach((img) => {
+      toggleBtnIcon(img);
+    });
+  }
+}
+
+export function handleColorGreen(actions: actions) {
+  switch (actions.allowed) {
+    case "playSong-main-top-song":
+      handleMainTopSong(actions.trackData);
+      break;
+    case "playSong-top-songs":
+      handleTopSongs(actions.trackData);
+      break;
+    case "playSong-Artists-Carrousel":
+      handleArtistCarrousel(actions.trackData);
+      break;
+    case "playSong-Album-Carrousel":
+      handleAlbumCarrousel(actions.trackData);
+      break;
+  }
+}

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,7 @@
+export function localStorageGet(key: string) {
+  return JSON.parse(localStorage.getItem(key) ?? "");
+}
+
+export function localStorageSet(key: string, element: any) {
+  localStorage.setItem(key, JSON.stringify(element));
+}


### PR DESCRIPTION
## Ticket reference
[URL](https://trello.com/c/vYJq8ARx/23-made-functionality-button-play-for-search-panel)


## Changes
- Add Play/Pause SVG icons with white color  
- Implement Spotify player action in search panel  
- Add localStorage utilities for track state management  
- Refactor play button functionality across components  

## How to test
1. Go to the search panel and search for any song
2. Click play → song should start and icon switches to pause  
3. Click pause → song stops and icon switches back to play  
4. Reload page → play buttons reset to default state  

## Checklist
- [ ] Play/Pause buttons work in search panel  
- [ ] Icons render correctly  
- [ ] Track state stored in localStorage  
- [ ] No UI regressions  
